### PR TITLE
Replace README.md with a symlink to readme.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,0 @@
-org-asana
-=========
-
-Roundtrip synchronization between Emacs Org-mode and Asana.com.
-
-Started by mengwong@pobox.com 20130202.
-
-See doc/readme.org.
-

--- a/readme.org
+++ b/readme.org
@@ -1,0 +1,1 @@
+doc/readme.org


### PR DESCRIPTION
Github knows how to read and display .org files - so there's no reason
to use MarkDown on its behalf.

There may be other reasons to want the README to be in markdown though - in which case this pull request should be rejected.
